### PR TITLE
Fix enabled method when name ends with *

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -209,7 +209,7 @@ function setup(env) {
 	* @api public
 	*/
 	function enabled(name) {
-		if (name[name.length - 1] === '*') {
+		if (name === '*') {
 			return true;
 		}
 

--- a/test.js
+++ b/test.js
@@ -118,4 +118,45 @@ describe('debug', () => {
 			assert.deepStrictEqual(oldSkips.map(String), debug.skips.map(String));
 		});
 	});
+
+	describe('check if a name is enabled', () => {
+		it('handles a name', () => {
+			debug.enable('test');
+			assert(debug.enabled('test'));
+			assert(!debug.enabled('abc'));
+		});
+
+		it('handles skip', () => {
+			debug.enable('test,abc*,-abc');
+			assert(debug.enabled('test'));
+			assert(!debug.enabled('abc'));
+		});
+
+		it('handles wildcards', () => {
+			debug.enable('test,abc*');
+			assert(!debug.enabled('foo:*'));
+			assert(debug.enabled('test'));
+			assert(debug.enabled('abc'));
+
+			debug.enable('abc:*');
+			assert(!debug.enabled('test:*'));
+			assert(!debug.enabled('test'));
+			assert(!debug.enabled('abc'));
+			assert(debug.enabled('abc:*'));
+
+			debug.enable('abc:*');
+			assert(debug.enabled('abc:foo'));
+		});
+
+		it('handles the * wildcard', () => {
+			debug.enable('test,abc*');
+			assert(debug.enabled('*'));
+
+			debug.enable('');
+			assert(debug.enabled('*'));
+
+			debug.enable('-*');
+			assert(debug.enabled('*'));
+		});
+	});
 });


### PR DESCRIPTION
I noticed an issue and I'm pretty sure it's a bug. Here's a PR solving my issue and adding tests for this bug.

The issue: `debug.enabled('foo:*')` is always true, because `name` ends with `*`.

If anyone runs into this issue before it is fixed, there is a workaround: `debug.enabled('foo:*,')`, this does the trick.