### PR TITLE
Fix only replacing wildcard at end in `toNamespace`

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -239,7 +239,7 @@ function setup(env) {
 	function toNamespace(regexp) {
 		return regexp.toString()
 			.substring(2, regexp.toString().length - 2)
-			.replace(/\.\*\?$/, '*');
+			.replace(/\.\*\?/, '*');
 	}
 
 	/**


### PR DESCRIPTION
The docs state that, when running `debug.disable()`, it will return the namespaces currently enabled and skipped. They are, however, often malformed. This seems to be because the `toNamespace` method only replaces a trailing `*`.

```javascript
debug.enable('api:*,-*:verbose,-api:*:verbose');
const prevConfig = debug.disable();
console.log(prevConfig); // -> api:*,-.*?:verbose,-api:.*?:verbose
```

`console.log(prevConfig);` should have returned `api:*,-*:verbose,-api:*:verbose`.

The issue seems to be fixed by removing the `$` in the replace regexp in `toNamespace`.

It might be nice to improve the following test too:
```javascript
describe('rebuild namespaces string (disable)', () => {
	it('handle names, skips, and wildcards', () => {
		debug.enable('test,abc*,-abc');
		const namespaces = debug.disable();
		assert.deepStrictEqual(namespaces, 'test,abc*,-abc');
		// ^ could use more tests, maybe: *,test,-test,abc*,*abc,abc:*:xyz,-abc:*:xyz,-*:verbose (etcetera)
	});
	// ...
});
```
However, for the sake of keeping this PR clean, I haven't added that to this PR.