### PR TITLE
Upgrade ms to version 2.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test:coverage": "cat ./coverage/lcov.info | coveralls"
   },
   "dependencies": {
-    "ms": "2.1.2"
+    "ms": "2.1.3"
   },
   "devDependencies": {
     "brfs": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test:coverage": "cat ./coverage/lcov.info | coveralls"
   },
   "dependencies": {
-    "ms": "2.1.3"
+    "ms": "^2.1.3"
   },
   "devDependencies": {
     "brfs": "^2.0.1",


### PR DESCRIPTION
This is a minor update only containing stylistic changes: https://github.com/vercel/ms/releases/tag/2.1.3

It's nice to have so it doesn't show up as an outdated dependency & so it deduplicates with other libraries using it.