### PR TITLE
Update version 4.3.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "debug",
-  "version": "4.3.3",
+  "version": "4.3.5",
   "repository": {
     "type": "git",
     "url": "git://github.com/debug-js/debug.git"


### PR DESCRIPTION
<!--

DO NOT SUBMIT PULL REQUESTS REMOVING ES6.

IT WILL BE CLOSED.
IT WILL NOT BE MERGED.

We use ES2015+ for a reason. Modern best
practices dictate the use of tooling like
Babel and @babel/preset-env in order to
target the browsers that make sense for
your project.

For more information, please see:
https://github.com/sindresorhus/ama/issues/446#issuecomment-281014491

-->
