### PR TITLE
Remove bad practices from ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ $ npm install debug
 Example [_app.js_](./examples/node/app.js):
 
 ```js
-var debug = require('debug')('http')
-  , http = require('http')
-  , name = 'My App';
+const debugFactory = require('debug')
+const debug = debugFactory('http')
+const name = 'My App'
 
 // fake app
 


### PR DESCRIPTION
From https://github.com/debug-js/debug/issues/786#issuecomment-1059397551
Requested by @jimmywarting and @Qix- 

This removes difficult to use ES5 conventions and prepares us for v5. As someone who started using Node after ES6 with ESM as much as possible, the code and the readme was hard to read.

ps your issue template is 5 years old and not particularly relevant today.