### PR TITLE
add namespace caching

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -146,9 +146,17 @@ function setup(env) {
 		return debug;
 	}
 
+	const debugCache = new Map();
 	function extend(namespace, delimiter) {
-		const newDebug = createDebug(this.namespace + (typeof delimiter === 'undefined' ? ':' : delimiter) + namespace);
+		const newNamespace = this.namespace +
+			(typeof delimiter === 'undefined' ? ':' : delimiter) +
+			namespace;
+		if (debugCache.has(newNamespace)) {
+			return debugCache.get(newNamespace);
+		}
+		const newDebug = createDebug(newNamespace);
 		newDebug.log = this.log;
+		debugCache.set(newNamespace, newDebug);
 		return newDebug;
 	}
 

--- a/test.js
+++ b/test.js
@@ -75,8 +75,18 @@ describe('debug', () => {
 			const log = debug('foo');
 			log.log = () => {};
 
-			const logBar = log.extend('bar');
-			assert.deepStrictEqual(log.log, logBar.log);
+			const logBaz = log.extend('baz');
+			assert.deepStrictEqual(log.log, logBaz.log);
+		});
+
+		it('should cache namespace extensions', () => {
+			const log = debug('foo');
+			log.log = () => {};
+
+			const logBar1 = log.extend('bar');
+			const logBar2 = log.extend('bar');
+			assert.deepStrictEqual(logBar1, logBar2);
+			assert.deepStrictEqual(logBar1.log, logBar2.log);
 		});
 	});
 


### PR DESCRIPTION
I'd like to be able to extend a namespace at a per-function call level like so:

```javascript
class Foo {
  constructor() {
    this.log = debug('Foo');
    this.log('init');
  }
  bar() {
    const log = this.log.extend('bar');
    log('bar');
  }
}
```

The trouble is that each time I call bar, I reset the clock, I'd rather get my timestamp diffs between calls to the same namespace.

While writing this and updating tests I realized that one of the tests relied on a lack of caching between one instantiation of a `foobar` namespace and another. So I updated that to use `foobaz` but it doesn't really address the more important question of _is this breaking behavior_?

If it is, but the maintainers still agree this is valuable, perhaps there could be an option to enable caching? Or we can lift it to the user layer to overwrite extend like we do with formatters and colors? Just spitballing here....