### PR TITLE
Exploratory PR for backwards-compatible changes & cross-env alignment: timeFormat

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ When actively developing an application it can be useful to see when the time sp
 
 <img width="647" src="https://user-images.githubusercontent.com/71256/29091486-fa38524c-7c37-11e7-895f-e7ec8e1039b6.png">
 
-When stdout is not a TTY, `Date#toISOString()` is used, making it more useful for logging the debug information as shown below:
+When stdout is not a TTY, `Date#toISOString()` is used by default (when `DEBUG_TIME_FORMAT` is `iso`, see [Environment variables](#environment-variables)), making it more useful for logging the debug information as shown below:
 
 <img width="647" src="https://user-images.githubusercontent.com/71256/29091956-6bd78372-7c39-11e7-8c55-c948396d6edd.png">
 
@@ -166,7 +166,8 @@ change the behavior of the debug logging:
 | Name      | Purpose                                         |
 |-----------|-------------------------------------------------|
 | `DEBUG`   | Enables/disables specific debugging namespaces. |
-| `DEBUG_HIDE_DATE` | Hide date from debug output (non-TTY).  |
+| `DEBUG_HIDE_DATE` | *(deprecated) - use DEBUG_TIME_FORMAT=none instead* Hide date from debug output (non-TTY).  |
+| `DEBUG_TIME_FORMAT` | One of `diff` (TTY & browser default),`iso` (non-TTY default),`none`,`localized` |
 | `DEBUG_COLORS`| Whether or not to use colors in the debug output. |
 | `DEBUG_DEPTH` | Object inspection depth.                    |
 | `DEBUG_SHOW_HIDDEN` | Shows hidden properties on inspected objects. |
@@ -177,6 +178,10 @@ converted into an Options object that gets used with `%o`/`%O` formatters.
 See the Node.js documentation for
 [`util.inspect()`](https://nodejs.org/api/util.html#util_util_inspect_object_options)
 for the complete list.
+
+__Note:__ In Node, if `DEBUG_TIME_FORMAT` is set to `localized`, you can control the timezone
+by setting `process.env.TZ` to a valid [IANA timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones),
+for example: `Europe/London`
 
 ## Formatters
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "test": "npm run test:node && npm run test:browser && npm run lint",
     "test:node": "istanbul cover _mocha -- test.js",
     "test:browser": "karma start --single-run",
-    "test:coverage": "cat ./coverage/lcov.info | coveralls"
+    "test:coverage": "cat ./coverage/lcov.info | coveralls",
+    "build:browser": "browserify -s debug -t brfs -o dist/debug.js src/browser.js"
   },
   "dependencies": {
     "ms": "2.1.2"

--- a/src/browser.js
+++ b/src/browser.js
@@ -8,6 +8,7 @@ exports.formatArgs = formatArgs;
 exports.save = save;
 exports.load = load;
 exports.useColors = useColors;
+exports.timeFormat = timeFormat;
 exports.storage = localstorage();
 exports.destroy = (() => {
 	let warned = false;
@@ -137,6 +138,10 @@ function useColors() {
 		(typeof navigator !== 'undefined' && navigator.userAgent && navigator.userAgent.toLowerCase().match(/applewebkit\/(\d+)/));
 }
 
+function timeFormat() {
+	return 'diff';
+}
+
 /**
  * Colorize log arguments if enabled.
  *
@@ -144,12 +149,13 @@ function useColors() {
  */
 
 function formatArgs(args) {
+	const wantsDiff = this.timeFormat === 'diff';
 	args[0] = (this.useColors ? '%c' : '') +
 		this.namespace +
 		(this.useColors ? ' %c' : ' ') +
-		args[0] +
+		(wantsDiff ? args[0] : module.exports.withTimeFormat(+new Date(), args[0], this.timeFormat)) +
 		(this.useColors ? '%c ' : ' ') +
-		'+' + module.exports.humanize(this.diff);
+		(wantsDiff ? module.exports.withTimeFormat(this.diff, '', this.timeFormat) : '');
 
 	if (!this.useColors) {
 		return;

--- a/src/common.js
+++ b/src/common.js
@@ -11,7 +11,9 @@ function setup(env) {
 	createDebug.disable = disable;
 	createDebug.enable = enable;
 	createDebug.enabled = enabled;
+	// no longer used, but kept accessible on createDebug for backwards-compatibility with debug <= 4.3.4
 	createDebug.humanize = require('ms');
+	createDebug.withTimeFormat = withTimeFormat;
 	createDebug.destroy = destroy;
 
 	Object.keys(env).forEach(key => {
@@ -115,6 +117,7 @@ function setup(env) {
 
 		debug.namespace = namespace;
 		debug.useColors = createDebug.useColors();
+		debug.timeFormat = createDebug.timeFormat();
 		debug.color = createDebug.selectColor(namespace);
 		debug.extend = extend;
 		debug.destroy = createDebug.destroy; // XXX Temporary. Will be removed in the next major release.
@@ -257,6 +260,41 @@ function setup(env) {
 		}
 		return val;
 	}
+
+function getLocalizedDate(dt) {
+	const offset = dt.getTimezoneOffset();
+	const offsetSign = offset <= 0 ? '+' : '-';
+
+	// some timezones have sub-hour offsets
+	let offsetMins = offset % 60
+	let offsetHours = (offset - offsetMins) / 60;
+	dt.setHours(dt.getHours() - offsetHours);
+	dt.setMinutes(dt.getMinutes() - offsetMins);
+	
+	const absMins = Math.abs(offsetMins);
+	const absHours = Math.abs(offsetHours);
+	offsetHours = offsetHours === 0 ? '00' : (absHours > 9 ? '' : '0') + absHours;
+	offsetMins = offsetMins === 0 ? '00' : (absMins > 9 ? '' : '0') + absMins;
+	// remove the 'Z' because it stands for UTC, returns in format like YYYY-MM-DD'T'HH:mm:ss.SSS +HH:mm
+	return dt.toISOString().slice(0, -1) + ' ' + offsetSign + offsetHours + ':' + offsetMins + ' ';
+}
+
+function withTimeFormat(date, str, format) {
+	switch (format) {
+		case 'iso':
+			return new Date(date).toISOString() + ' ' + str; 
+			break;
+		case 'localized':
+			return getLocalizedDate(new Date(date)) + ' ' + str;
+			break;
+		case 'none':
+			return str;
+			break;
+		case 'diff':
+		default:
+			return str + '+' + createDebug.humanize(date);
+	}
+}
 
 	/**
 	* XXX DO NOT USE. This is a temporary stub function.


### PR DESCRIPTION
I started this effort because I was in sore need of localized dates (we have Java & Node microservices and it's a pain that one takes into account timezone while the other does not). Then I realized there was a lot more I could do that would be both backwards-compatible, more powerful and more aligned across browser and Node. So this PR:

* Adds timeFormat option to debug instances, settable as DEBUG_TIME_FORMAT env var
* Deprecates hideDate option, equated to timeFormat === 'none'
* Allows timeFormat of choice: none, iso, diff, or localized (taking into account process.env.TZ in Node, and timezoneOffset in browser)
* Normalizes behavior across browser & Node: all timeFormats are available in both, but the defaults are kept as-is.
* Deprecates createDebug.humanize as public member and adds createDebug.withTimeFormat helper instead
* Documents this in the README.
* Adds debug format tests that are compatible with browser & Node.

@Qix- I was surprised at how outdated (dev)Dependencies are and was unable to run `npm test` (only `mocha test.js` directly).
The browserify build was not documented so I added an NPM script for it.. It may be useful to add it to the NPM files for those of us wanting to use debug in the browser by copying the dist to an asset folder.
