### PR TITLE
Fix/debug depth

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,12 +26,13 @@
   "scripts": {
     "lint": "xo",
     "test": "npm run test:node && npm run test:browser && npm run lint",
-    "test:node": "istanbul cover _mocha -- test.js",
+    "test:node": "istanbul cover _mocha -- test.js test.node.js",
     "test:browser": "karma start --single-run",
     "test:coverage": "cat ./coverage/lcov.info | coveralls"
   },
   "dependencies": {
-    "ms": "2.1.2"
+    "ms": "2.1.2",
+    "sinon": "^14.0.0"
   },
   "devDependencies": {
     "brfs": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -31,8 +31,7 @@
     "test:coverage": "cat ./coverage/lcov.info | coveralls"
   },
   "dependencies": {
-    "ms": "2.1.2",
-    "sinon": "^14.0.0"
+    "ms": "2.1.2"
   },
   "devDependencies": {
     "brfs": "^2.0.1",
@@ -45,6 +44,7 @@
     "karma-mocha": "^1.3.0",
     "mocha": "^5.2.0",
     "mocha-lcov-reporter": "^1.2.0",
+    "sinon": "^14.0.0",
     "xo": "^0.23.0"
   },
   "peerDependenciesMeta": {

--- a/src/node.js
+++ b/src/node.js
@@ -187,11 +187,11 @@ function getDate() {
 }
 
 /**
- * Invokes `util.format()` with the specified arguments and writes to stderr.
+ * Invokes `util.formatWithOptions()` with the specified arguments and writes to stderr.
  */
 
 function log(...args) {
-	return process.stderr.write(util.format(...args) + '\n');
+	return process.stderr.write(util.formatWithOptions(exports.inspectOpts, ...args) + '\n');
 }
 
 /**

--- a/test.node.js
+++ b/test.node.js
@@ -1,0 +1,40 @@
+/* eslint-env mocha */
+
+const assert = require('assert');
+const util = require('util');
+const sinon = require('sinon');
+const debug = require('./src/node');
+
+const formatWithOptionsSpy = sinon.spy(util, 'formatWithOptions');
+beforeEach(() => {
+	formatWithOptionsSpy.resetHistory();
+});
+
+describe('debug node', () => {
+	describe('formatting options', () => {
+		it('calls util.formatWithOptions', () => {
+			debug.enable('*');
+			const stdErrWriteStub = sinon.stub(process.stderr, 'write');
+			const log = debug('formatting options');
+			log('hello world');
+			assert(util.formatWithOptions.callCount === 1);
+			stdErrWriteStub.restore();
+		});
+
+		it('calls util.formatWithOptions with inspectOpts', () => {
+			debug.enable('*');
+			const options = {
+				hideDate: true,
+				colors: true,
+				depth: 10,
+				showHidden: true
+			};
+			Object.assign(debug.inspectOpts, options);
+			const stdErrWriteStub = sinon.stub(process.stderr, 'write');
+			const log = debug('format with inspectOpts');
+			log('hello world2');
+			assert.deepStrictEqual(util.formatWithOptions.getCall(0).args[0], options);
+			stdErrWriteStub.restore();
+		});
+	});
+});


### PR DESCRIPTION
This PR fixes https://github.com/debug-js/debug/issues/746

It comes complete with mocha tests.

@Qix- Apologies for the mess on on the previous PR https://github.com/debug-js/debug/issues/746 as forgot about the PR completely and have been pushing various fixes to it.

This will also fix up all other issues related to the `DEBUG` env variables not being registered. The main issue is that `util.format` needs to be replaced with `util.formatWithOptions`, to receive `export.inspectOpts` that has the `DEBUG` env variables.