### PR TITLE
remove 22kb readme, use link instead

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "files": [
     "src",
     "LICENSE",
-    "README.md"
+    "readme-link"
   ],
   "author": "Josh Junon (https://github.com/qix-)",
   "contributors": [

--- a/readme-link
+++ b/readme-link
@@ -1,0 +1,1 @@
+https://raw.githubusercontent.com/debug-js/debug/refs/tags/4.3.7/README.md


### PR DESCRIPTION
Simple change, makes the unpacked size half of what it currently is while still having a link to the readme, which at 32,659,277 (rounding to 33) means this could save on the order of 0.6TB of internet traffic per week (34.4TB yearly).