### PR TITLE
Require supports-color <9

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,9 @@
     "sinon": "^14.0.0",
     "xo": "^0.23.0"
   },
+  "peerDependencies": {
+    "supports-color": "<9.0.0"
+  },
   "peerDependenciesMeta": {
     "supports-color": {
       "optional": true


### PR DESCRIPTION
Fixes https://github.com/debug-js/debug/issues/975

`require('supports-color')` [in debug/src/node.js](https://github.com/debug-js/debug/blob/bc60914816e5e45a5fff1cd638410438fc317521/src/node.js#L32) should require the CommonJS version of the supports-color package (version 8 or below) rather than ESM, because this package uses CommonJS modules.

`require`ing ESM modules/packages from CommonJS modules is still [experimental](https://nodejs.org/docs/latest-v23.x/api/all.html#all_documentation_stability-index) and "not recommended in production environments".