### PR TITLE
Fix node.js file.

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -29,7 +29,7 @@ exports.colors = [6, 2, 3, 4, 5, 1];
 try {
 	// Optional dependency (as in, doesn't need to be installed, NOT like optionalDependencies in package.json)
 	// eslint-disable-next-line import/no-extraneous-dependencies
-	const supportsColor = require('supports-color');
+	const supportsColor = import('supports-color');
 
 	if (supportsColor && (supportsColor.stderr || supportsColor).level >= 2) {
 		exports.colors = [


### PR DESCRIPTION
This fix removes the error message require supports-color in esm (Node ver. 23.2.0).