### PR TITLE
support inlined process.env.DEBUG

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -225,9 +225,12 @@ function load() {
 		// XXX (@Qix-) should we be logging these?
 	}
 
-	// If debug isn't set in LS, and we're in Electron, try to load $DEBUG
-	if (!r && typeof process !== 'undefined' && 'env' in process) {
-		r = process.env.DEBUG;
+	if (!r) {
+		try {
+			r = process.env.DEBUG;
+		} catch (error) {
+			// Swallow
+		}
 	}
 
 	return r;


### PR DESCRIPTION
Some browser-like environments do not support localStorage nor process.env, but can be provided environment variables because they automatically get inlined (i.e. process.env.XYZ gets replaced by whatever value XYZ is during a build step). This change supports this scenario without breaking previous behavior.