### PR TITLE
fix: backslashes in template string didn't work after release 4.4.0

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -195,13 +195,15 @@ function setup(env) {
 		let starIndex = -1;
 		let matchIndex = 0;
 
+		const skippedChars = ['*', '\\']
+
 		while (searchIndex < search.length) {
-			if (templateIndex < template.length && (template[templateIndex] === search[searchIndex] || template[templateIndex] === '*')) {
-				// Match character or proceed with wildcard
-				if (template[templateIndex] === '*') {
+			if (templateIndex < template.length && (template[templateIndex] === search[searchIndex] || skippedChars.includes(template[templateIndex]))) {
+				// Match character or proceed with wildcard or backslash
+				if (skippedChars.includes(template[templateIndex])) {
 					starIndex = templateIndex;
 					matchIndex = searchIndex;
-					templateIndex++; // Skip the '*'
+					templateIndex++; // Skip the '*' or '\'
 				} else {
 					searchIndex++;
 					templateIndex++;

--- a/test.js
+++ b/test.js
@@ -53,6 +53,13 @@ describe('debug', () => {
 			assert.deepStrictEqual(logBar.namespace, 'foo:bar');
 		});
 
+		it('handle escaped characters', () => {
+			debug.enable('\\[*');
+			const inst = debug('[foo');
+
+			assert.deepStrictEqual(inst.enabled, true);
+		});
+
 		it('should extend namespace with custom delimiter', () => {
 			const log = debug('foo');
 			log.enabled = true;


### PR DESCRIPTION
Hello, 

Backslashes in template string is not taken into account after the changes made in the new `matchesTemplate` function from [4.4.0](https://github.com/debug-js/debug/releases/tag/4.4.0). 

When you need to escape a character (like `[` which is not valid as template string unless escaped), the debug is disabled because the character doesn't match the namespace. 

This PR is adding backslash as a special character