### PR TITLE
fixes #987 fallback to localStorage.DEBUG if debug is not defined

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -219,7 +219,7 @@ function save(namespaces) {
 function load() {
 	let r;
 	try {
-		r = exports.storage.getItem('debug');
+		r = exports.storage.getItem('debug') || exports.storage.getItem('DEBUG') ;
 	} catch (error) {
 		// Swallow
 		// XXX (@Qix-) should we be logging these?


### PR DESCRIPTION
Tweak to address #987. From that issue:

> I often get tripped up by the fact that I need to set `localStorage.debug` but in the node environment its `DEBUG` (lower versus upper case). It would be a nice enhancement if the debug package in the browser checked `localStorage.debug || localStorage.DEBUG`, if it did, it would save me an (embarrassing) amount of time.