### PR TITLE
Add missing colon (:)

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ log('still goes to stdout, but via console.info now');
 ```
 
 ## Extend
-You can simply extend debugger 
+You can simply extend debugger:
 ```js
 const log = require('debug')('auth');
 


### PR DESCRIPTION
This commit adds a missing colon (:) at the end of a sentence. This minor fix makes the instructions clearer and aligns with standard writing conventions.