### PR TITLE
fix(Issue-996): replace whitespaces in namespaces string with commas globally

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -168,7 +168,7 @@ function setup(env) {
 
 		const split = (typeof namespaces === 'string' ? namespaces : '')
 			.trim()
-			.replace(' ', ',')
+			.replace(/\s+/g, ',')
 			.split(',')
 			.filter(Boolean);
 


### PR DESCRIPTION
This change uses a regex to replace whitespaces in namespaces string with commas globally instead of just the first space occurrence. This fixes the issue reported below.


Issue: https://github.com/debug-js/debug/issues/996
In the following code in src/common.js, the namespaces string with multiple space delimiters is incorrectly only split at the occurrence of first space due to the replace() function only replacing the first occurrence of space with a comma. This leads to a names array of only two string elements with the second element possibly being incorrect. The replace() function should replace spaces with commas globally.

```
const split = (typeof namespaces === 'string' ? namespaces : '')
			.trim()
			.replace(' ', ',')
			.split(',')
			.filter(Boolean);

		for (const ns of split) {
			if (ns[0] === '-') {
				createDebug.skips.push(ns.slice(1));
			} else {
				createDebug.names.push(ns);
			}
		}
```