### PR TITLE
Fix broken repository URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "4.4.1",
   "repository": {
     "type": "git",
-    "url": "git://github.com/debug-js/debug.git"
+    "url": "https://github.com/debug-js/debug.git"
   },
   "description": "Lightweight debugging utility for Node.js and the browser",
   "keywords": [


### PR DESCRIPTION
GitHub hasn't supported the git protocol [since 2022](https://github.blog/security/application-security/improving-git-protocol-security-github/#no-more-unauthenticated-git), so this URL is broken.

(This is a common error affecting many projects and I'm opening PRs in bulk to fix it.)