### PR TITLE
Add peer dependency on supports-color v8

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,9 @@
     "sinon": "^14.0.0",
     "xo": "^0.23.0"
   },
+  "peerDependencies": {
+    "supports-color": "^8.0.0"
+  },
   "peerDependenciesMeta": {
     "supports-color": {
       "optional": true


### PR DESCRIPTION
## Summary

- Adds `peerDependencies.supports-color` at `^8.0.0`, matching the existing optional `peerDependenciesMeta` entry.
- Helps npm and other package managers avoid pulling in supports-color v9+, which is ESM-only and breaks debug's CommonJS `require()` (see #912).

Fixes #947

## Test plan

- [x] `npm run test:node` (16 passing)