### PR TITLE
fix: honor DEBUG_HIDE_DATE when set as a flag

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -148,6 +148,12 @@ exports.inspectOpts = Object.keys(process.env).filter(key => {
 	return obj;
 }, {});
 
+// `DEBUG_HIDE_DATE` is commonly set as a flag without a value.
+if (Object.prototype.hasOwnProperty.call(process.env, 'DEBUG_HIDE_DATE') &&
+	process.env.DEBUG_HIDE_DATE === '') {
+	exports.inspectOpts.hideDate = true;
+}
+
 /**
  * Is stdout a TTY? Colored output is enabled when `true`.
  */

--- a/test.node.js
+++ b/test.node.js
@@ -1,6 +1,7 @@
 /* eslint-env mocha */
 
 const assert = require('assert');
+const {spawnSync} = require('child_process');
 const util = require('util');
 const sinon = require('sinon');
 const debug = require('./src/node');
@@ -35,6 +36,34 @@ describe('debug node', () => {
 			log('hello world2');
 			assert.deepStrictEqual(util.formatWithOptions.getCall(0).args[0], options);
 			stdErrWriteStub.restore();
+		});
+
+		it('honors DEBUG_HIDE_DATE when set as a flag', () => {
+			const script = `
+				const tty = require('tty');
+				tty.isatty = () => false;
+				const debug = require('./src/node');
+				debug.enable('test');
+				const log = debug('test');
+				const args = ['hello'];
+				debug.formatArgs.call(log, args);
+				process.stdout.write(args[0]);
+			`;
+
+			for (const hideDate of ['', '1', 'true']) {
+				const result = spawnSync(process.execPath, ['-e', script], {
+					cwd: __dirname,
+					env: {
+						...process.env,
+						DEBUG: 'test',
+						DEBUG_HIDE_DATE: hideDate
+					},
+					encoding: 'utf8'
+				});
+
+				assert.strictEqual(result.status, 0, result.stderr);
+				assert.strictEqual(result.stdout, 'test hello');
+			}
 		});
 	});
 });


### PR DESCRIPTION
Fixes #959

## Summary
- Treat an empty `DEBUG_HIDE_DATE` value as enabled so the documented env var works when used as a flag
- Add a regression test covering empty, `1`, and `true` values in non-TTY output

## Test plan
- [x] `npm run test:node`