### PR TITLE
Escape percent signs in formatter output

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -98,6 +98,7 @@ function setup(env) {
 				if (typeof formatter === 'function') {
 					const val = args[index];
 					match = formatter.call(self, val);
+					match = String(match).replace(/%/g, '%%');
 
 					// Now we need to remove `args[index]` since it's inlined in the `format`
 					args.splice(index, 1);

--- a/test.js
+++ b/test.js
@@ -43,6 +43,19 @@ describe('debug', () => {
 		assert.deepStrictEqual(messages.length, 3);
 	});
 
+	it('escapes percent signs returned by custom formatters', () => {
+		const log = debug('test');
+		log.enabled = true;
+		debug.formatters.x = () => '%j';
+
+		const messages = [];
+		log.log = (...args) => messages.push(args);
+		log('%x', null, 1);
+
+		assert(messages[0][0].includes('%%j'));
+		delete debug.formatters.x;
+	});
+
 	describe('extend namespace', () => {
 		it('should extend namespace', () => {
 			const log = debug('foo');

--- a/test.node.js
+++ b/test.node.js
@@ -36,5 +36,22 @@ describe('debug node', () => {
 			assert.deepStrictEqual(util.formatWithOptions.getCall(0).args[0], options);
 			stdErrWriteStub.restore();
 		});
+
+		it('does not interpret percent signs in formatter output', () => {
+			debug.enable('*');
+			const options = {
+				hideDate: true,
+				colors: false
+			};
+			Object.assign(debug.inspectOpts, options);
+			const stdErrWriteStub = sinon.stub(process.stderr, 'write');
+			const log = debug('percent');
+			log('%o', {'%j': '%j %j %%'}, 1, 2, 3);
+			assert.strictEqual(
+				stdErrWriteStub.firstCall.firstArg,
+				'percent { \'%j\': \'%j %j %%\' } 1 2 3\n'
+			);
+			stdErrWriteStub.restore();
+		});
 	});
 });


### PR DESCRIPTION
Fixes #766.

Custom formatter output is inlined into the first format argument, then interpreted again by Node's `util.formatWithOptions` or the browser console. Percent sequences inside inspected objects were therefore treated as new format specifiers and consumed trailing arguments.

This stringifies formatter results and escapes their percent signs before inlining them. The downstream formatting pass converts `%%` back to literal `%`, preserving the formatter output and leaving subsequent arguments untouched. Explicit `%%` sequences in the user's original format string still follow the existing path unchanged.

Validation:
- `npm run test:node -- --reporter dot` — 18 passing
- XO on the changed files under Node 20 — no errors (existing warnings only)
- regression coverage for both the Node `%o` formatter and the shared custom formatter path

The repository's pinned XO stack does not run on Node 24 because a transitive dependency calls the removed `util.isDate`; lint was therefore run with Node 20.