### PR TITLE
fix: make disable() namespaces round-trip through enable()

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -174,11 +174,19 @@ function setup(env) {
 
 		for (const ns of split) {
 			if (ns[0] === '-') {
-				createDebug.skips.push(ns.slice(1));
+				createDebug.skips.push(toNamespace(ns.slice(1)));
 			} else {
-				createDebug.names.push(ns);
+				createDebug.names.push(toNamespace(ns));
 			}
 		}
+	}
+
+	// Invert historic '*' → '.*?' encoding so disable()/enable() can round-trip.
+	function toNamespace(namespace) {
+		const value = namespace instanceof RegExp ?
+			namespace.source.replace(/^\^/, '').replace(/\$$/, '') :
+			String(namespace);
+		return value.replace(/\.\*\?/g, '*');
 	}
 
 	/**
@@ -232,8 +240,8 @@ function setup(env) {
 	*/
 	function disable() {
 		const namespaces = [
-			...createDebug.names,
-			...createDebug.skips.map(namespace => '-' + namespace)
+			...createDebug.names.map(toNamespace),
+			...createDebug.skips.map(namespace => '-' + toNamespace(namespace))
 		].join(',');
 		createDebug.enable('');
 		return namespaces;

--- a/test.js
+++ b/test.js
@@ -118,6 +118,25 @@ describe('debug', () => {
 			assert.deepStrictEqual(oldSkips.map(String), debug.skips.map(String));
 		});
 
+		it('round-trips wildcard namespaces including skips', () => {
+			debug.enable('*:error:*,-*:error:ignore');
+			const namespaces = debug.disable();
+			assert.deepStrictEqual(namespaces, '*:error:*,-*:error:ignore');
+			assert.doesNotThrow(() => debug.enable(namespaces));
+			assert.deepStrictEqual(debug.enabled('api:error:db'), true);
+			assert.deepStrictEqual(debug.enabled('api:error:ignore'), false);
+			assert.deepStrictEqual(debug.enabled('api:warn:db'), false);
+		});
+
+		it('accepts historic disable() wildcard encoding', () => {
+			debug.enable('.*?:error:*,-.*?:verbose');
+			const namespaces = debug.disable();
+			assert.deepStrictEqual(namespaces, '*:error:*,-*:verbose');
+			assert.doesNotThrow(() => debug.enable(namespaces));
+			assert.deepStrictEqual(debug.enabled('api:error:db'), true);
+			assert.deepStrictEqual(debug.enabled('api:verbose'), false);
+		});
+
 		it('handles re-enabling existing instances', () => {
 			debug.disable('*');
 			const inst = debug('foo');


### PR DESCRIPTION
`enable(disable())` should restore the same namespaces, including mid-string wildcards and skip patterns.

`disable()` historically rebuilt the namespace string from compiled regexes and only inverted a trailing `.*?`. A pattern such as `*:error:*` came back as `.*?:error:*`, which `enable()` then rejected (`Invalid regular expression: Nothing to repeat`).

Normalize that historic `.*?` encoding back to `*` when enabling and when rebuilding the disable() string, so the documented temporary-disable round-trip works for wildcards and skips.

Fixes #918