### PR TITLE
docs: drop dead wzrd.in standalone browser build link

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,8 +214,8 @@ debug('this is hex: %h', new Buffer('hello world'))
 
 ## Browser Support
 
-You can build a browser-ready script using [browserify](https://github.com/substack/node-browserify),
-or just use the [browserify-as-a-service](https://wzrd.in/) [build](https://wzrd.in/standalone/debug@latest),
+You can build a browser-ready script using [browserify](https://github.com/browserify/browserify),
+or just use the [jsDelivr](https://www.jsdelivr.com/package/npm/debug) [build](https://cdn.jsdelivr.net/npm/debug@latest/src/browser.js),
 if you don't want to build it yourself.
 
 Debug's enable state is currently persisted by `localStorage`.

--- a/README.md
+++ b/README.md
@@ -214,9 +214,7 @@ debug('this is hex: %h', new Buffer('hello world'))
 
 ## Browser Support
 
-You can build a browser-ready script using [browserify](https://github.com/browserify/browserify),
-or just use the [jsDelivr](https://www.jsdelivr.com/package/npm/debug) [build](https://cdn.jsdelivr.net/npm/debug@latest/src/browser.js),
-if you don't want to build it yourself.
+You can build a browser-ready script using [browserify](https://github.com/browserify/browserify).
 
 Debug's enable state is currently persisted by `localStorage`.
 Consider the situation shown below where you have `worker:a` and `worker:b`,


### PR DESCRIPTION
## Problem

`https://wzrd.in/standalone/debug@latest` now returns HTTP 404 on GET. The README still advertised that hosted browserify-as-a-service build.

`https://github.com/substack/node-browserify` still works, but the project lives at `https://github.com/browserify/browserify`.

## Change

- Remove the dead wzrd.in standalone-build promise.
- Keep the local browserify instructions and point that repo at its current org URL.

Verified with `curl -L GET` on 2026-08-17:

- `https://wzrd.in/standalone/debug@latest` -> 404
- `https://github.com/browserify/browserify` -> 200
