### PR TITLE
docs: correct %d and document %f in the formatters table

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,8 @@ Below are the officially supported formatters:
 | `%O`      | Pretty-print an Object on multiple lines. |
 | `%o`      | Pretty-print an Object all on a single line. |
 | `%s`      | String. |
-| `%d`      | Number (both integer and float). |
+| `%d`      | Integer (printf `%d`; floats are truncated toward zero). |
+| `%f`      | Floating-point number. |
 | `%j`      | JSON. Replaced with the string '[Circular]' if the argument contains circular references. |
 | `%%`      | Single percent sign ('%'). This does not consume an argument. |
 


### PR DESCRIPTION
## Problem

The formatters table documents `%d` as "Number (both integer and float)". That is inaccurate and matches issue #913, where a float passed to `%d` is truncated: in Node.js the log call goes through `util.formatWithOptions` (see `src/node.js` `log()`), whose `%d` is printf-style integer formatting. The table also omits `%f`, which `util.format` supports for floats.

## Solution

- Describe `%d` as integer formatting (floats truncated toward zero).
- Add a `%f` row for floating-point numbers.

Node example confirming current behavior:

```js
const createDebug = require('./src/node')('t');
createDebug.log = (...a) => console.log(require('util').formatWithOptions({}, ...a));
createDebug('int %d float %f', 3.7, 3.7); // int 3 float 3.7
```

## Verification

- `%d` / `%f` behavior verified against `util.format()` on current Node.js.
- No code change; documentation only.
