### PR TITLE
docs: fix hex example to match the Buffer it formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,8 +207,8 @@ createDebug.formatters.h = (v) => {
 
 // …elsewhere
 const debug = createDebug('foo')
-debug('this is hex: %h', new Buffer('hello world'))
-//   foo this is hex: 68656c6c6f20776f726c6421 +0ms
+debug('this is hex: %h', Buffer.from('hello world'))
+//   foo this is hex: 68656c6c6f20776f726c64 +0ms
 ```
 
 


### PR DESCRIPTION
## Problem

The custom formatters example reads:

```js
debug('this is hex: %h', new Buffer('hello world'))
//   foo this is hex: 68656c6c6f20776f726c6421 +0ms
```

Two things are wrong:

1. `new Buffer(...)` is deprecated since Node.js 6; the modern equivalent is `Buffer.from(...)`.
2. The shown output ends with `21` (the hex of `!`), which is not part of the input string `'hello world'`. `Buffer.from('hello world').toString('hex')` is `68656c6c6f20776f726c64`.

## Solution

Use `Buffer.from` and drop the stray `21` so the comment matches the actual formatter output.

## Verification

```js
Buffer.from('hello world').toString('hex')
// '68656c6c6f20776f726c64'
```

Documentation-only change.
